### PR TITLE
improve: add JNI calls for improved performance

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -46,6 +46,7 @@ android {
 
     defaultConfig {
         minSdk = 24
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     testOptions {
@@ -73,6 +74,7 @@ kotlin {
 
 dependencies {
     implementation("androidx.documentfile:documentfile:1.1.0")
+    implementation("androidx.annotation:annotation:1.9.1")
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.mockito:mockito-core:5.0.0")
 }

--- a/android/consumer-rules.pro
+++ b/android/consumer-rules.pro
@@ -1,0 +1,11 @@
+# SafStreamJni is never referenced by any Dart-generated or Java/Kotlin
+# static call -- it's looked up purely by string name at runtime via JNI
+# (JClass.forName("com/fluttercavalry/saf_stream/SafStreamJni") from Dart).
+# R8 has no static call graph edge to it, so in a release build it gets
+# stripped (or renamed, which breaks the string lookup just as badly) unless
+# explicitly kept.
+#
+# This is a *consumer* rule: it ships inside the plugin's AAR and is
+# automatically applied to any app that depends on this plugin, with no
+# action needed in the app's own proguard rules.
+-keep class com.fluttercavalry.saf_stream.SafStreamJni { *; }

--- a/android/src/main/kotlin/com/fluttercavalry/saf_stream/SafStreamJni.kt
+++ b/android/src/main/kotlin/com/fluttercavalry/saf_stream/SafStreamJni.kt
@@ -1,0 +1,166 @@
+package com.fluttercavalry.saf_stream
+
+import android.content.Context
+import androidx.annotation.Keep
+import androidx.core.net.toUri
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * JNI-callable bridge used for the hot, byte-heavy read/write paths.
+ *
+ * Called directly from Dart at runtime via package:jni's low-level API
+ * (`JClass.forName` + `staticMethodId` + `.call(...)`), NOT via jnigen
+ * codegen -- same reasoning as before (jnigen can't resolve
+ * `android.content.Context` etc. at codegen time; at runtime the JVM
+ * already has these classes loaded, so reflective lookup sidesteps that).
+ *
+ * Payloads are now raw `ByteArray` ([B), not Base64 Strings. package:jni
+ * has a documented type for this (`JByteArray`, source-verified in
+ * pkgs/jni/lib/src/primitive_jarrays.dart: `JByteArray.of(Iterable<int>)`
+ * to build one from Dart bytes, `.getRange(start, end)` to pull the bytes
+ * back out) -- the byte[] marshalling this class previously avoided *is*
+ * supported, it just isn't in the one hand-picked example on pub.dev.
+ * Base64 was costing 33% extra bytes on the wire plus encode/decode CPU
+ * on both sides, on top of transcoding a large String through JNI's
+ * modified-UTF-8 twice per chunk. None of that is needed.
+ */
+@Keep
+object SafStreamJni {
+    @JvmStatic
+    @Volatile
+    var appContext: Context? = null
+
+    private val inputStreams = ConcurrentHashMap<String, InputStream>()
+    private val outputStreams = ConcurrentHashMap<String, OutputStream>()
+    private val readBuffers = ConcurrentHashMap<String, ByteArray>()
+    private val EMPTY = ByteArray(0)
+
+    private fun ctx(): Context =
+        appContext ?: throw IllegalStateException("SafStreamJni.appContext has not been initialized")
+
+    // ---------------------------------------------------------------------
+    // Reading
+    // ---------------------------------------------------------------------
+
+    fun registerInputStream(
+        session: String,
+        stream: InputStream,
+    ) {
+        inputStreams[session] = stream
+    }
+
+    /**
+     * Reads up to [length] bytes from the stream registered under
+     * [session]. Returns an empty (zero-length) array at EOF. Called
+     * directly from Dart via JNI, in a loop -- this is the hot path.
+     *
+     * Reuses a per-session buffer instead of allocating a fresh `length`
+     * -byte array on every call: at a 64 KB chunk size against a 100 MB
+     * file that's ~1600 allocations (and matching GC churn) removed.
+     */
+    @JvmStatic
+    fun readChunk(
+        session: String,
+        length: Int,
+    ): ByteArray {
+        val stream = inputStreams[session] ?: throw Exception("Read stream not found for session: $session")
+        var buffer = readBuffers[session]
+        if (buffer == null || buffer.size != length) {
+            buffer = ByteArray(length)
+            readBuffers[session] = buffer
+        }
+        val n = stream.read(buffer, 0, length)
+        if (n <= 0) return EMPTY
+        return if (n == length) buffer else buffer.copyOf(n)
+    }
+
+    /** Skips [count] bytes on the stream registered under [session]. */
+    @JvmStatic
+    fun skipInput(
+        session: String,
+        count: Long,
+    ): Long {
+        val stream = inputStreams[session] ?: throw Exception("Read stream not found for session: $session")
+        return stream.skip(count)
+    }
+
+    /** Closes and unregisters the input stream for [session]. */
+    @JvmStatic
+    fun closeInputStream(session: String) {
+        inputStreams.remove(session)?.close()
+        readBuffers.remove(session)
+    }
+
+    /**
+     * One-shot read (backs `readFileBytes`). Not chunked, so a plain JNI
+     * call (no session bookkeeping) is enough; still skips the
+     * MethodChannel codec round trip for what can be a very large payload.
+     */
+    @JvmStatic
+    fun readFileBytes(
+        uriStr: String,
+        start: Long,
+        count: Int,
+    ): ByteArray {
+        val stream =
+            ctx().contentResolver.openInputStream(uriStr.toUri())
+                ?: throw Exception("Failed to open input stream for $uriStr")
+        stream.use {
+            if (start > 0) {
+                it.skip(start)
+            }
+            return if (count > 0) {
+                val buffer = ByteArray(count)
+                val n = it.read(buffer, 0, count)
+                if (n <= 0) EMPTY else buffer.copyOf(n)
+            } else {
+                it.buffered().readBytes()
+            }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Writing
+    // ---------------------------------------------------------------------
+
+    fun registerOutputStream(
+        session: String,
+        stream: OutputStream,
+    ) {
+        outputStreams[session] = stream
+    }
+
+    /**
+     * Writes [data] to the stream registered under [session]. Called
+     * directly from Dart via JNI, once per chunk -- this is the hot path
+     * that used to be a `writeChunk` MethodChannel call per chunk.
+     */
+    @JvmStatic
+    fun writeChunk(
+        session: String,
+        data: ByteArray,
+    ) {
+        val stream = outputStreams[session] ?: throw Exception("Write stream not found for session: $session")
+        stream.write(data)
+    }
+
+    /** Flushes, closes and unregisters the output stream for [session]. */
+    @JvmStatic
+    fun closeOutputStream(session: String) {
+        outputStreams.remove(session)?.let {
+            it.flush()
+            it.close()
+        }
+    }
+
+    /** Used for cleanup if a session is abandoned (e.g. app killed mid-stream). */
+    fun reset() {
+        inputStreams.values.forEach { runCatching { it.close() } }
+        outputStreams.values.forEach { runCatching { it.close() } }
+        inputStreams.clear()
+        outputStreams.clear()
+        readBuffers.clear()
+    }
+}

--- a/android/src/main/kotlin/com/fluttercavalry/saf_stream/SafStreamPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercavalry/saf_stream/SafStreamPlugin.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import androidx.core.net.toUri
 import androidx.documentfile.provider.DocumentFile
 import io.flutter.embedding.engine.plugins.FlutterPlugin
-import io.flutter.plugin.common.EventChannel
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -14,7 +13,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import java.io.File
 import java.io.FileInputStream
-import java.io.InputStream
 import java.io.OutputStream
 
 /** SafStreamPlugin */
@@ -28,12 +26,14 @@ class SafStreamPlugin :
     private lateinit var channel: MethodChannel
     private lateinit var context: Context
     private var pluginBinding: FlutterPlugin.FlutterPluginBinding? = null
-    private var writeStreams = mutableMapOf<String, OutputStream>()
-    private var customReadStreams = mutableMapOf<String, CustomReadStream>()
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
         pluginBinding = flutterPluginBinding
         context = flutterPluginBinding.applicationContext
+        // Hand the Android Context to the JNI bridge so methods called
+        // directly from Dart (bypassing this MethodChannel) can still reach
+        // the ContentResolver.
+        SafStreamJni.appContext = context
         channel = MethodChannel(flutterPluginBinding.binaryMessenger, "saf_stream")
         channel.setMethodCallHandler(this)
     }
@@ -44,28 +44,26 @@ class SafStreamPlugin :
     ) {
         when (call.method) {
             "readFileStream" -> {
+                // Only opens the stream and registers it with the JNI bridge
+                // under `session`. Actual chunk reads happen via direct JNI
+                // calls to `SafStreamJni.readChunk` from Dart, not through an
+                // EventChannel. This avoids one BinaryMessenger round trip
+                // per chunk.
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
-                        // Arguments are enforced on dart side.
                         val fileUriStr = call.argument<String>("fileUri")!!
                         val session = call.argument<String>("session")!!
-                        val bufferSize = call.argument<Int>("bufferSize") ?: (4 * 1024 * 1024)
                         val start = (call.argument<Number>("start")?.toLong()) ?: 0L
 
                         val inStream =
                             context.contentResolver.openInputStream(fileUriStr.toUri())
                                 ?: throw Exception("Stream creation failed")
+                        if (start != 0L) {
+                            inStream.skip(start)
+                        }
+                        SafStreamJni.registerInputStream(session, inStream)
                         launch(Dispatchers.Main) {
-                            val streamHandler = ReadFileHandler(inStream, bufferSize, start)
-                            val channelName = "saf_stream/readFile/$session"
-                            EventChannel(
-                                pluginBinding?.binaryMessenger,
-                                channelName,
-                            ).setStreamHandler(
-                                streamHandler,
-                            )
-
-                            result.success(channelName)
+                            result.success(session)
                         }
                     } catch (err: Exception) {
                         launch(Dispatchers.Main) {
@@ -97,29 +95,19 @@ class SafStreamPlugin :
             }
 
             "readFileBytes" -> {
+                // Note: this path is also directly callable from Dart via JNI
+                // (`SafStreamJni.readFileBytes`), skipping this MethodChannel
+                // entirely. It's kept here too so the plugin still works for
+                // any caller that only wired up the MethodChannel side (e.g.
+                // during a partial migration, or on hosts where the JNI
+                // plugin failed to initialize).
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
-                        val fileUriStr = call.argument<String>("fileUri")!!.toUri()
+                        val fileUriStr = call.argument<String>("fileUri")!!
                         val start = (call.argument<Number>("start")?.toLong()) ?: 0L
-                        val count = call.argument<Int>("count")
+                        val count = call.argument<Int>("count") ?: -1
 
-                        val bytes =
-                            context.contentResolver.openInputStream(fileUriStr)?.use {
-                                if (start > 0) {
-                                    it.skip(start)
-                                }
-                                if (count != null) {
-                                    val buffer = ByteArray(count)
-                                    val read = it.read(buffer, 0, count)
-                                    if (read <= 0) {
-                                        ByteArray(0)
-                                    } else {
-                                        buffer.copyOf(read)
-                                    }
-                                } else {
-                                    it.buffered().readBytes()
-                                }
-                            }
+                        val bytes = SafStreamJni.readFileBytes(fileUriStr, start, count)
                         launch(Dispatchers.Main) {
                             result.success(bytes)
                         }
@@ -216,9 +204,8 @@ class SafStreamPlugin :
                         map["uri"] = newFile.uri.toString()
                         map["fileName"] = newFile.name
 
+                        SafStreamJni.registerOutputStream(session, outStream)
                         launch(Dispatchers.Main) {
-                            // Access `writeStreams` in main thread.
-                            writeStreams[session] = outStream
                             result.success(map)
                         }
                     } catch (err: Exception) {
@@ -229,79 +216,58 @@ class SafStreamPlugin :
                 }
             }
 
+            // `writeChunk` and `endWriteStream` are no longer called from
+            // Dart in the normal path -- Dart calls `SafStreamJni.writeChunk`
+            // / `SafStreamJni.closeOutputStream` directly via JNI instead, to
+            // avoid one MethodChannel round trip per chunk. These handlers
+            // are kept as a MethodChannel-only fallback.
             "writeChunk" -> {
-                try {
-                    val session = call.argument<String>("session")!!
-                    // Access `writeStreams` in main thread.
-                    val outStream = writeStreams[session]
-                    if (outStream == null) {
-                        result.error("PluginError", "Stream not found", null)
-                    } else {
-                        CoroutineScope(Dispatchers.IO).launch {
-                            try {
-                                val data = call.argument<ByteArray>("data")!!
-                                outStream.write(data)
-                                launch(Dispatchers.Main) { result.success(null) }
-                            } catch (err: Exception) {
-                                launch(Dispatchers.Main) {
-                                    result.error("PluginError", err.message, null)
-                                }
-                            }
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val session = call.argument<String>("session")!!
+                        val data = call.argument<ByteArray>("data")!!
+                        SafStreamJni.writeChunk(session, data)
+                        launch(Dispatchers.Main) { result.success(null) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) {
+                            result.error("PluginError", err.message, null)
                         }
                     }
-                } catch (err: Exception) {
-                    result.error("PluginError", err.message, null)
                 }
             }
 
             "endWriteStream" -> {
-                try {
-                    val session = call.argument<String>("session")!!
-                    // Access `writeStreams` in main thread.
-                    val outStream = writeStreams[session]
-                    if (outStream == null) {
-                        result.error("PluginError", "Stream not found", null)
-                    } else {
-                        CoroutineScope(Dispatchers.IO).launch {
-                            try {
-                                outStream.close()
-                                launch(Dispatchers.Main) {
-                                    writeStreams.remove(session)
-                                    result.success(null)
-                                }
-                            } catch (err: Exception) {
-                                launch(Dispatchers.Main) {
-                                    writeStreams.remove(session)
-                                    result.error(
-                                        "CloseWriteStreamError",
-                                        err.message,
-                                        null,
-                                    )
-                                }
-                            }
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val session = call.argument<String>("session")!!
+                        SafStreamJni.closeOutputStream(session)
+                        launch(Dispatchers.Main) { result.success(null) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) {
+                            result.error("CloseWriteStreamError", err.message, null)
                         }
                     }
-                } catch (err: Exception) {
-                    result.error("PluginError", err.message, null)
                 }
             }
 
+            // The custom-read-stream family shares the exact same registry as
+            // `readFileStream` now (`SafStreamJni.inputStreams`), keyed by
+            // session. `readCustomFileStreamChunk` / `skipCustomFileStreamChunk`
+            // / `endReadCustomFileStream` are no longer called from Dart in
+            // the normal path -- Dart calls `SafStreamJni.readChunk` /
+            // `skipInput` / `closeInputStream` directly via JNI. These
+            // handlers remain as a MethodChannel-only fallback.
             "startReadCustomFileStream" -> {
                 CoroutineScope(Dispatchers.IO).launch {
                     try {
                         val fileUriStr = call.argument<String>("fileUri")!!
                         val session = call.argument<String>("session")!!
-                        val bufferSize = call.argument<Int>("bufferSize") ?: (4 * 1024 * 1024)
 
                         val inStream =
                             context.contentResolver.openInputStream(fileUriStr.toUri())
                                 ?: throw Exception("Stream creation failed")
-                        launch(Dispatchers.Main) {
-                            val customStream = CustomReadStream(inStream, bufferSize)
-                            customReadStreams[session] = customStream
-
-                            result.success(null)
-                        }
+                        SafStreamJni.registerInputStream(session, inStream)
+                        launch(Dispatchers.Main) { result.success(null) }
                     } catch (err: Exception) {
                         launch(Dispatchers.Main) {
                             result.error("PluginError", err.message, null)
@@ -311,85 +277,48 @@ class SafStreamPlugin :
             }
 
             "readCustomFileStreamChunk" -> {
-                try {
-                    val session = call.argument<String>("session")!!
-                    val customStream = customReadStreams[session]
-                    if (customStream == null) {
-                        result.error("PluginError", "Stream not found", null)
-                    } else {
-                        CoroutineScope(Dispatchers.IO).launch {
-                            try {
-                                val rc = customStream.read()
-                                if (rc == -1) {
-                                    launch(Dispatchers.Main) { result.success(null) }
-                                } else {
-                                    val chunk = customStream.buffer.copyOf(rc)
-                                    launch(Dispatchers.Main) { result.success(chunk) }
-                                }
-                            } catch (err: Exception) {
-                                launch(Dispatchers.Main) {
-                                    result.error("PluginError", err.message, null)
-                                }
-                            }
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val session = call.argument<String>("session")!!
+                        val bufferSize = call.argument<Int>("bufferSize") ?: (4 * 1024 * 1024)
+                        val bytes = SafStreamJni.readChunk(session, bufferSize)
+                        launch(Dispatchers.Main) {
+                            result.success(if (bytes.isEmpty()) null else bytes)
+                        }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) {
+                            result.error("PluginError", err.message, null)
                         }
                     }
-                } catch (err: Exception) {
-                    result.error("PluginError", err.message, null)
                 }
             }
 
             "skipCustomFileStreamChunk" -> {
-                try {
-                    val session = call.argument<String>("session")!!
-                    val count = call.argument<Int>("count")!!
-                    val customStream = customReadStreams[session]
-                    if (customStream == null) {
-                        result.error("PluginError", "Stream not found", null)
-                    } else {
-                        CoroutineScope(Dispatchers.IO).launch {
-                            try {
-                                val skipped = customStream.skip(count.toLong())
-                                launch(Dispatchers.Main) { result.success(skipped.toInt()) }
-                            } catch (err: Exception) {
-                                launch(Dispatchers.Main) {
-                                    result.error("PluginError", err.message, null)
-                                }
-                            }
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val session = call.argument<String>("session")!!
+                        val count = call.argument<Int>("count")!!
+                        val skipped = SafStreamJni.skipInput(session, count.toLong())
+                        launch(Dispatchers.Main) { result.success(skipped.toInt()) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) {
+                            result.error("PluginError", err.message, null)
                         }
                     }
-                } catch (err: Exception) {
-                    result.error("PluginError", err.message, null)
                 }
             }
 
             "endReadCustomFileStream" -> {
-                try {
-                    val session = call.argument<String>("session")!!
-                    val customStream = customReadStreams[session]
-                    if (customStream == null) {
-                        result.error("PluginError", "Stream not found", null)
-                    } else {
-                        CoroutineScope(Dispatchers.IO).launch {
-                            try {
-                                customStream.close()
-                                launch(Dispatchers.Main) {
-                                    customReadStreams.remove(session)
-                                    result.success(null)
-                                }
-                            } catch (err: Exception) {
-                                launch(Dispatchers.Main) {
-                                    customReadStreams.remove(session)
-                                    result.error(
-                                        "CloseReadStreamError",
-                                        err.message,
-                                        null,
-                                    )
-                                }
-                            }
+                CoroutineScope(Dispatchers.IO).launch {
+                    try {
+                        val session = call.argument<String>("session")!!
+                        SafStreamJni.closeInputStream(session)
+                        launch(Dispatchers.Main) { result.success(null) }
+                    } catch (err: Exception) {
+                        launch(Dispatchers.Main) {
+                            result.error("CloseReadStreamError", err.message, null)
                         }
                     }
-                } catch (err: Exception) {
-                    result.error("PluginError", err.message, null)
                 }
             }
 
@@ -462,57 +391,4 @@ class SafStreamPlugin :
         }
 }
 
-class ReadFileHandler(
-    private val inStream: InputStream,
-    private val bufferSize: Int,
-    private val start: Long,
-) : EventChannel.StreamHandler {
-    private var eventSink: EventChannel.EventSink? = null
-    private var cancelled = false
 
-    override fun onListen(
-        p0: Any?,
-        sink: EventChannel.EventSink,
-    ) {
-        eventSink = sink
-        CoroutineScope(Dispatchers.IO).launch {
-            try {
-                val buffer = ByteArray(bufferSize)
-                inStream.use { stream ->
-                    if (start != 0L) {
-                        stream.skip(start)
-                    }
-                    var rc: Int = stream.read(buffer)
-                    while (rc != -1 && !cancelled) {
-                        val chunk = buffer.copyOf(rc)
-                        launch(Dispatchers.Main) { sink.success(chunk) }
-                        rc = stream.read(buffer)
-                    }
-                    launch(Dispatchers.Main) { sink.endOfStream() }
-                }
-            } catch (err: Exception) {
-                launch(Dispatchers.Main) { sink.error("ReadFileError", err.message, null) }
-            }
-        }
-    }
-
-    override fun onCancel(p0: Any?) {
-        eventSink = null
-        cancelled = true
-    }
-}
-
-class CustomReadStream(
-    private val inStream: InputStream,
-    bufferSize: Int,
-) {
-    var buffer = ByteArray(bufferSize)
-
-    fun skip(n: Long): Long = inStream.skip(n)
-
-    fun read(): Int = inStream.read(buffer)
-
-    fun close() {
-        inStream.close()
-    }
-}

--- a/lib/saf_stream_jni_io.dart
+++ b/lib/saf_stream_jni_io.dart
@@ -1,0 +1,164 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:jni/jni.dart';
+
+
+///    `JStaticMethodId`s are resolved once and cached (`static final`,
+///    matching the pattern package:jni's own generated bindings use in
+///    `core_bindings.dart`), not re-resolved with `staticMethodId(...)` on
+///    every chunk. `GetStaticMethodID` is a reflective symbol-table lookup;
+///    at a 64 KB chunk size against a 100 MB file that's ~1600 lookups per
+///    direction that were previously happening on every single call.
+class SafStreamJniIo {
+  SafStreamJniIo._();
+
+  static final JClass _class =
+      JClass.forName('com/fluttercavalry/saf_stream/SafStreamJni');
+
+  static final _idReadChunk =
+      _class.staticMethodId('readChunk', '(Ljava/lang/String;I)[B');
+  static final _idSkipInput =
+      _class.staticMethodId('skipInput', '(Ljava/lang/String;J)J');
+  static final _idCloseInputStream =
+      _class.staticMethodId('closeInputStream', '(Ljava/lang/String;)V');
+  static final _idWriteChunk =
+      _class.staticMethodId('writeChunk', '(Ljava/lang/String;[B)V');
+  static final _idCloseOutputStream =
+      _class.staticMethodId('closeOutputStream', '(Ljava/lang/String;)V');
+  static final _idReadFileBytes = _class.staticMethodId(
+      'readFileBytes', '(Ljava/lang/String;JI)[B');
+
+  static Uint8List _readChunk(String session, int length) {
+    final jSession = session.toJString();
+    try {
+      final jResult = _idReadChunk.call(
+        _class,
+        JByteArray.type,
+        [jSession, length],
+      );
+      try {
+        return _toUint8List(jResult);
+      } finally {
+        jResult.release();
+      }
+    } finally {
+      jSession.release();
+    }
+  }
+
+  /// Pull-based chunked read. Replaces the old EventChannel-pushed stream:
+  /// Dart now asks for chunks in a loop instead of native code pushing
+  /// them, which also means reads can be paused/cancelled without extra
+  /// plumbing (just stop calling readChunk).
+  static Stream<Uint8List> readStream(
+    String session, {
+    required int bufferSize,
+  }) {
+    late StreamController<Uint8List> controller;
+    var cancelled = false;
+
+    Future<void> pump() async {
+      try {
+        while (!cancelled) {
+          final chunk = _readChunk(session, bufferSize);
+          if (chunk.isEmpty) break;
+          controller.add(chunk);
+        }
+      } catch (err, st) {
+        if (!cancelled) controller.addError(err, st);
+      } finally {
+        if (!cancelled) await controller.close();
+        endRead(session);
+      }
+    }
+
+    controller = StreamController<Uint8List>(
+      onListen: () {
+        unawaited(pump());
+      },
+      onCancel: () {
+        cancelled = true;
+      },
+    );
+    return controller.stream;
+  }
+
+  /// Single chunk pull, used by the `startReadCustomFileStream` /
+  /// `readCustomFileStreamChunk` family. Returns null at EOF.
+  static Uint8List? readCustomChunk(String session, int bufferSize) {
+    final chunk = _readChunk(session, bufferSize);
+    return chunk.isEmpty ? null : chunk;
+  }
+
+  static int skip(String session, int count) {
+    final jSession = session.toJString();
+    try {
+      return _idSkipInput.call(_class, jlong.type, [jSession, count]);
+    } finally {
+      jSession.release();
+    }
+  }
+
+  static void endRead(String session) {
+    final jSession = session.toJString();
+    try {
+      _idCloseInputStream.call(_class, jvoid.type, [jSession]);
+    } finally {
+      jSession.release();
+    }
+  }
+
+  static void writeChunk(String session, Uint8List data) {
+    final jSession = session.toJString();
+    final jData = JByteArray.from(data);
+    try {
+      _idWriteChunk.call(_class, jvoid.type, [jSession, jData]);
+    } finally {
+      jSession.release();
+      jData.release();
+    }
+  }
+
+  static void endWrite(String session) {
+    final jSession = session.toJString();
+    try {
+      _idCloseOutputStream.call(_class, jvoid.type, [jSession]);
+    } finally {
+      jSession.release();
+    }
+  }
+
+  static Uint8List readFileBytes(String uri, {required int start, required int count}) {
+    final jUri = uri.toJString();
+    try {
+      final jResult = _idReadFileBytes.call(
+        _class,
+        JByteArray.type,
+        [jUri, start, count],
+      );
+      try {
+        return _toUint8List(jResult);
+      } finally {
+        jResult.release();
+      }
+    } finally {
+      jUri.release();
+    }
+  }
+
+  /// `JByteArray.getRange` returns an `Int8List` view over natively
+  /// allocated (malloc'd) memory. Java `byte` and Dart's `Uint8List` are
+  /// both single bytes with the same bit pattern (just a signed/unsigned
+  /// read of it), so this reinterprets the same buffer instead of copying
+  /// element-by-element -- the copy still has to happen once (native
+  /// malloc'd memory can't be handed to the rest of Dart as-is), but this
+  /// does it as a single `memcpy`-backed `Uint8List.fromList` on the
+  /// underlying bytes rather than the signed/unsigned-aware element loop.
+  static Uint8List _toUint8List(JByteArray jArray) {
+    final n = jArray.length;
+    if (n == 0) return Uint8List(0);
+    final int8 = jArray.getRange(0, n);
+    return Uint8List.fromList(int8.buffer.asUint8List(int8.offsetInBytes, n));
+  }
+}

--- a/lib/saf_stream_method_channel.dart
+++ b/lib/saf_stream_method_channel.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
 
 import 'saf_stream_platform_interface.dart';
+import 'saf_stream_jni_io.dart';
 
 /// An implementation of [SafStreamPlatform] that uses method channels.
 class MethodChannelSafStream extends SafStreamPlatform {
@@ -17,19 +18,19 @@ class MethodChannelSafStream extends SafStreamPlatform {
     int? bufferSize,
     int? start,
   }) async {
-    final session = _nextSession();
-    final channelName = await methodChannel
-        .invokeMethod<String>('readFileStream', {
-          'fileUri': uri.toString(),
-          'session': session.toString(),
-          'bufferSize': bufferSize,
-          'start': start,
-        });
-    if (channelName == null) {
-      throw Exception('Unexpected empty channel name from `readFile`');
-    }
-    final stream = EventChannel(channelName);
-    return stream.receiveBroadcastStream().map((e) => e as Uint8List);
+    // `readFileStream` on the native side now only opens the stream and
+    // registers it under `session` (see SafStreamPlugin.kt) -- a single
+    // MethodChannel call. Every chunk after that is pulled directly via JNI
+    // in SafStreamJniIo.readStream, with no EventChannel and no per-chunk
+    // BinaryMessenger round trip.
+    final session = _nextSession().toString();
+    final effectiveBufferSize = bufferSize ?? (4 * 1024 * 1024);
+    await methodChannel.invokeMethod<String>('readFileStream', {
+      'fileUri': uri.toString(),
+      'session': session,
+      'start': start,
+    });
+    return SafStreamJniIo.readStream(session, bufferSize: effectiveBufferSize);
   }
 
   @override
@@ -43,15 +44,13 @@ class MethodChannelSafStream extends SafStreamPlatform {
         throw ArgumentError('`count` must be greater than 0');
       }
     }
-    final res = await methodChannel.invokeMethod<Uint8List>('readFileBytes', {
-      'fileUri': uri.toString(),
-      'start': start,
-      'count': count,
-    });
-    if (res == null) {
-      throw Exception('Unexpected empty response from `readFileBytes`');
-    }
-    return res;
+    // One-shot read, straight through JNI: skips the MethodChannel codec
+    // round trip entirely for what can be a very large byte array.
+    return SafStreamJniIo.readFileBytes(
+      uri.toString(),
+      start: start,
+      count: count ?? -1,
+    );
   }
 
   @override
@@ -178,18 +177,21 @@ class MethodChannelSafStream extends SafStreamPlatform {
 
   @override
   Future<void> writeChunk(String session, Uint8List data) async {
-    return await methodChannel.invokeMethod<void>('writeChunk', {
-      'session': session.toString(),
-      'data': data,
-    });
+    // Direct JNI call -- this is what used to be one `invokeMethod` per
+    // chunk. For a multi-MB file written in, say, 64KB chunks that's
+    // hundreds of MethodChannel round trips avoided.
+    SafStreamJniIo.writeChunk(session, data);
   }
 
   @override
   Future<void> endWriteStream(String session) async {
-    return await methodChannel.invokeMethod<void>('endWriteStream', {
-      'session': session.toString(),
-    });
+    SafStreamJniIo.endWrite(session);
   }
+
+  // `_customBufferSizes` remembers the bufferSize passed to
+  // startReadCustomFileStream, since readCustomFileStreamChunk no longer
+  // takes one per call (it just asks JNI for "the next chunk").
+  final _customBufferSizes = <String, int>{};
 
   @override
   Future<String> startReadCustomFileStream(
@@ -197,36 +199,32 @@ class MethodChannelSafStream extends SafStreamPlatform {
     int? bufferSize,
   }) async {
     final session = _nextSession().toString();
+    final effectiveBufferSize = bufferSize ?? (4 * 1024 * 1024);
+    // Setup-only MethodChannel call: opens the stream and registers it under
+    // `session`. Subsequent chunk reads go straight through JNI.
     await methodChannel.invokeMethod<String>('startReadCustomFileStream', {
       'fileUri': uri.toString(),
       'session': session,
-      'bufferSize': bufferSize,
     });
+    _customBufferSizes[session] = effectiveBufferSize;
     return session;
   }
 
   @override
   Future<Uint8List?> readCustomFileStreamChunk(String session) async {
-    return await methodChannel.invokeMethod<Uint8List>(
-      'readCustomFileStreamChunk',
-      {'session': session.toString()},
-    );
+    final bufferSize = _customBufferSizes[session] ?? (4 * 1024 * 1024);
+    return SafStreamJniIo.readCustomChunk(session, bufferSize);
   }
 
   @override
   Future<int> skipCustomFileStreamChunk(String session, int count) async {
-    final res = await methodChannel.invokeMethod<int>(
-      'skipCustomFileStreamChunk',
-      {'session': session.toString(), 'count': count},
-    );
-    return res ?? 0;
+    return SafStreamJniIo.skip(session, count);
   }
 
   @override
   Future<void> endReadCustomFileStream(String session) async {
-    await methodChannel.invokeMethod<void>('endReadCustomFileStream', {
-      'session': session.toString(),
-    });
+    _customBufferSizes.remove(session);
+    SafStreamJniIo.endRead(session);
   }
 
   int _nextSession() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,8 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.2
+  # Used to call into the Android-side SafStreamJni bridge directly
+  jni: ^0.14.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Add JNI-based read/write path , faster than MethodChannel

### Summary

Adds a JNI bridge for the byte-heavy read/write paths (`SafStreamJni.kt` / `saf_stream_jni_io.dart`), used in place of MethodChannel for the hot per-chunk calls. Session setup (opening the DocumentFile, resolving the stream) still goes through MethodChannel as before — only the repeated per-chunk read/write calls are routed through JNI, avoiding a `BinaryMessenger` codec round trip per chunk.

Payloads are marshalled as raw `byte[]` / `JByteArray` (`JByteArray.from` / `.getRange`), and the JNI method IDs used on the hot path are resolved once and cached as `static final` fields rather than looked up per call.

### Benchmark

100 MB file, 3 repeats, median, on-device (POCO F4 GT android 16 AOSP):

JNI version:

| Chunk | Write ms | Write MB/s | Read ms | Read MB/s |
|---|---|---|---|---|
| 64 KB | 598 | 167.22 | 351 | 284.90 |
| 256 KB | 673 | 148.59 | 235 | 425.53 |
| 1 MB | 674 | 148.37 | 227 | 440.53 |
| 4 MB | 810 | 123.46 | 341 | 293.26 |

MethodChannel original, for reference:

| Chunk | Write ms | Write MB/s | Read ms | Read MB/s |
|---|---|---|---|---|
| 64 KB | 1880 | 53.19 | 810 | 123.46 |
| 256 KB | 1286 | 77.76 | 576 | 173.61 |
| 1 MB | 1146 | 87.26 | 422 | 236.97 |
| 4 MB | 1062 | 94.16 | 585 | 170.94 |

<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/c8f3e4e0-5e40-4714-83a5-2decec9be502" />
<img width="270" height="600" alt="image" src="https://github.com/user-attachments/assets/8df07954-0b1f-48a7-bc3d-0452a9fc1eb0" />


JNI is faster at every chunk size tested , up to ~3.1x on writes and ~2.6x on reads at 64 KB, still ahead at 4 MB.

No public Dart API changes , `SafStreamJniIo`'s method signatures match the existing plugin surface.

Checkout https://github.com/Neo-vortex/saf_benchmark/releases/tag/v20.0 for benchmark apks used to get results

Closes #4